### PR TITLE
RAS-0024: Fixed parentheses ordering causing incorrect yaw calculations

### DIFF
--- a/detect_drowsiness.py
+++ b/detect_drowsiness.py
@@ -345,7 +345,7 @@ class LandmarkDetector:
         rtn_matrix = np.array(mp_matrix)[:3, :3]
 
         pitch = np.degrees(np.arctan2(-rtn_matrix[1, 2], rtn_matrix[2, 2]))
-        yaw   = np.degrees(np.arctan2(rtn_matrix[0, 2],  np.sqrt(rtn_matrix[1, 2] ** 2) + rtn_matrix[2, 2] **2 ))
+        yaw   = np.degrees(np.arctan2(rtn_matrix[0, 2],  np.sqrt(rtn_matrix[1, 2] ** 2 + rtn_matrix[2, 2] **2 )))
 
         return yaw, pitch
 


### PR DESCRIPTION
**Results:**
Yaw is calculated as expected after fix.

Before (image referenced from #45):
<img width="1054" height="84" alt="image" src="https://github.com/user-attachments/assets/b6c84c3a-4b4a-4768-ab6e-3160ad266ae6" />

After:
<img width="886" height="64" alt="image" src="https://github.com/user-attachments/assets/22b0471f-cc3c-4d4b-8829-43f9feacb629" />

Changes to base values are a result of camera angle positioning.
